### PR TITLE
Automating website URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Have you always been bugged that you need to renew your web server in pythonanyw
 
 1. Install the latest release executable for your operating system.
 2. Install the template auth.json file.
-3. Open and edit the auth.json to include your credentials.
+3. Open and edit the auth.json to include your credentials. **Due to formatting differences, the password should contain letters only.**
 4. Have the executable run on startup.
 
 When using the executable for Mac or Linux, run `chmod -x renewer-mac` (or Linux) and `chmod -r auth.json`. Due to strict restrictions with macOS executables, the executable must run with sudo permissions. This is why it is recommended to use Python or docker to run the renewer on mac instead.

--- a/auth.json
+++ b/auth.json
@@ -1,5 +1,4 @@
 {
     "username": "ENTER USERNAME FOR PYTHONANYWHERE HERE",
     "password": "ENTER PASSWORD FOR PYTHONANYWHERE HERE",
-    "pythonanywhere_domain": "ENTER THE PYTHONANYWHERE DOMAIN HERE"
 }

--- a/renewer.py
+++ b/renewer.py
@@ -17,7 +17,7 @@ with open('auth.json', 'r') as f:
 
 username = auth['username']
 password = auth['password']
-domain = auth['pythonanywhere_domain']
+domain = f'{username}.pythonanywhere.com'
 
 #We retrieve csrf token and sessionid by requesting /login
 lgnhead = requests.get("https://www.pythonanywhere.com/login/").cookies


### PR DESCRIPTION
Deleted the field in the json file and automated it in the python file, so there is no need in that field. ( because free users can only have website url like {username}.pythonanywhere.com )